### PR TITLE
Fix chat sync message retention and add delivery acknowledgements

### DIFF
--- a/Affirmate/Chat/ChatsView/ChatsObserver.swift
+++ b/Affirmate/Chat/ChatsView/ChatsObserver.swift
@@ -145,7 +145,7 @@ final class ChatsObserver: ObservableObject {
         }
         
         update(message: &message, from: messageContent, chat: chat)
-        
+
         if let participants = chat.participants as? Set<Participant> {
             if let sender = participants.first(where: { $0.id == messageContent.sender.id }) {
                 message.sender = sender
@@ -154,8 +154,14 @@ final class ChatsObserver: ObservableObject {
                 message.recipient = recipient
             }
         }
-        
+
         try managedObjectContext.save()
+
+        if let chatId = chat.id, let chatObserver = chatObservers[chatId] {
+            Task { @MainActor in
+                chatObserver.sendDeliveryConfirmation(for: messageContent.id)
+            }
+        }
     }
     
     /// Update a participant with the content from the server

--- a/AffirmateServer/Sources/AffirmateServer/Chat/ChatWebSocketManager.swift
+++ b/AffirmateServer/Sources/AffirmateServer/Chat/ChatWebSocketManager.swift
@@ -31,7 +31,7 @@ actor ChatWebSocketManager: WebSocketManager {
                     await self.handle(connect: connectMessage, request: request, webSocket: webSocket)
 
                 // MARK: Message
-                } else if let confirmationMessage = try self.get(buffer, MessageRecievedConfirmation.self) {
+                } else if let confirmationMessage = try? self.get(buffer, MessageRecievedConfirmation.self) {
                     await self.handle(messageConfirmation: confirmationMessage, request: request, webSocket: webSocket)
                 } else if let webSocketMessage = try self.get(buffer, MessageCreate.self) {
                     await self.handle(chatMessage: webSocketMessage, request: request, webSocket: webSocket)

--- a/AffirmateServer/Tests/AffirmateServerTests/ChatRouteCollectionTests.swift
+++ b/AffirmateServer/Tests/AffirmateServerTests/ChatRouteCollectionTests.swift
@@ -1,0 +1,81 @@
+//
+//  ChatRouteCollectionTests.swift
+//  AffirmateServerTests
+//
+//  Created by OpenAI on 2024.
+//
+
+@testable import AffirmateServer
+import AffirmateShared
+import XCTVapor
+import XCTest
+
+final class ChatRouteCollectionTests: XCTestCase {
+
+    func testSyncDeletesOnlyMessagesForCurrentUser() async throws {
+        let app = Application(.testing)
+        defer { app.shutdown() }
+        try! app.setUp()
+        defer { app.tearDown() }
+
+        // Create two users.
+        let passwordHash = try Bcrypt.hash("Test123$")
+        let userOne = User(firstName: "First", lastName: "User", username: "user1", email: "user1@example.com", passwordHash: passwordHash)
+        try await userOne.save(on: app.db)
+        let userTwo = User(firstName: "Second", lastName: "User", username: "user2", email: "user2@example.com", passwordHash: passwordHash)
+        try await userTwo.save(on: app.db)
+
+        let chat = Chat(id: UUID(), name: "Test Chat", salt: Data("salt".utf8))
+        try await chat.save(on: app.db)
+
+        let publicKeyOne = PublicKey(signingKey: Data("signing1".utf8), encryptionKey: Data("encryption1".utf8), user: try userOne.requireID(), chat: try chat.requireID())
+        try await publicKeyOne.save(on: app.db)
+        let publicKeyTwo = PublicKey(signingKey: Data("signing2".utf8), encryptionKey: Data("encryption2".utf8), user: try userTwo.requireID(), chat: try chat.requireID())
+        try await publicKeyTwo.save(on: app.db)
+
+        let participantOne = Participant(role: .admin, user: try userOne.requireID(), chat: try chat.requireID(), publicKey: try publicKeyOne.requireID())
+        try await participantOne.save(on: app.db)
+        let participantTwo = Participant(role: .participant, user: try userTwo.requireID(), chat: try chat.requireID(), publicKey: try publicKeyTwo.requireID())
+        try await participantTwo.save(on: app.db)
+
+        let messageForUserOne = Message(
+            id: UUID(),
+            ephemeralPublicKeyData: Data("e1".utf8),
+            ciphertext: Data("c1".utf8),
+            signature: Data("s1".utf8),
+            chat: try chat.requireID(),
+            sender: try participantTwo.requireID(),
+            recipient: try participantOne.requireID()
+        )
+        try await messageForUserOne.save(on: app.db)
+
+        let messageForUserTwo = Message(
+            id: UUID(),
+            ephemeralPublicKeyData: Data("e2".utf8),
+            ciphertext: Data("c2".utf8),
+            signature: Data("s2".utf8),
+            chat: try chat.requireID(),
+            sender: try participantOne.requireID(),
+            recipient: try participantTwo.requireID()
+        )
+        try await messageForUserTwo.save(on: app.db)
+
+        let sessionToken = try userOne.generateToken()
+        try await sessionToken.save(on: app.db)
+
+        try await app.test(.GET, "/chats") { request in
+            request.headers.bearerAuthorization = BearerAuthorization(token: sessionToken.value)
+        } afterResponse: { response in
+            XCTAssertEqual(response.status, .ok)
+            let chatResponses = try response.content.decode([ChatResponse].self)
+            XCTAssertEqual(chatResponses.count, 1)
+            XCTAssertEqual(chatResponses.first?.messages.count, 1)
+            XCTAssertEqual(chatResponses.first?.messages.first?.id, try messageForUserOne.requireID())
+        }
+
+        let remainingMessages = try await Message.query(on: app.db).all()
+        XCTAssertEqual(remainingMessages.count, 1)
+        let remaining = try XCTUnwrap(remainingMessages.first)
+        XCTAssertEqual(remaining.id, try messageForUserTwo.requireID())
+    }
+}

--- a/AffirmateServer/Tests/AffirmateServerTests/ChatWebSocketManagerTests.swift
+++ b/AffirmateServer/Tests/AffirmateServerTests/ChatWebSocketManagerTests.swift
@@ -1,0 +1,76 @@
+//
+//  ChatWebSocketManagerTests.swift
+//  AffirmateServerTests
+//
+//  Created by OpenAI on 2024.
+//
+
+@testable import AffirmateServer
+import XCTVapor
+import XCTest
+
+final class ChatWebSocketManagerTests: XCTestCase {
+
+    func testDeleteMessageIfAuthorizedOnlyDeletesRecipientMessages() async throws {
+        let app = Application(.testing)
+        defer { app.shutdown() }
+        try! app.setUp()
+        defer { app.tearDown() }
+
+        let passwordHash = try Bcrypt.hash("Test123$")
+        let userOne = User(firstName: "First", lastName: "User", username: "user1", email: "user1@example.com", passwordHash: passwordHash)
+        try await userOne.save(on: app.db)
+        let userTwo = User(firstName: "Second", lastName: "User", username: "user2", email: "user2@example.com", passwordHash: passwordHash)
+        try await userTwo.save(on: app.db)
+
+        let chat = Chat(id: UUID(), name: "Test Chat", salt: Data("salt".utf8))
+        try await chat.save(on: app.db)
+
+        let publicKeyOne = PublicKey(signingKey: Data("signing1".utf8), encryptionKey: Data("encryption1".utf8), user: try userOne.requireID(), chat: try chat.requireID())
+        try await publicKeyOne.save(on: app.db)
+        let publicKeyTwo = PublicKey(signingKey: Data("signing2".utf8), encryptionKey: Data("encryption2".utf8), user: try userTwo.requireID(), chat: try chat.requireID())
+        try await publicKeyTwo.save(on: app.db)
+
+        let participantOne = Participant(role: .admin, user: try userOne.requireID(), chat: try chat.requireID(), publicKey: try publicKeyOne.requireID())
+        try await participantOne.save(on: app.db)
+        let participantTwo = Participant(role: .participant, user: try userTwo.requireID(), chat: try chat.requireID(), publicKey: try publicKeyTwo.requireID())
+        try await participantTwo.save(on: app.db)
+
+        let messageForUserOne = Message(
+            id: UUID(),
+            ephemeralPublicKeyData: Data("e1".utf8),
+            ciphertext: Data("c1".utf8),
+            signature: Data("s1".utf8),
+            chat: try chat.requireID(),
+            sender: try participantTwo.requireID(),
+            recipient: try participantOne.requireID()
+        )
+        try await messageForUserOne.save(on: app.db)
+
+        let messageForUserTwo = Message(
+            id: UUID(),
+            ephemeralPublicKeyData: Data("e2".utf8),
+            ciphertext: Data("c2".utf8),
+            signature: Data("s2".utf8),
+            chat: try chat.requireID(),
+            sender: try participantOne.requireID(),
+            recipient: try participantTwo.requireID()
+        )
+        try await messageForUserTwo.save(on: app.db)
+
+        let manager = ChatWebSocketManager(eventLoop: app.eventLoopGroup.next())
+
+        try await manager.deleteMessageIfAuthorized(try messageForUserOne.requireID(), currentUser: userOne, chat: chat, database: app.db)
+
+        let deletedMessage = try await Message.find(messageForUserOne.requireID(), on: app.db)
+        XCTAssertNil(deletedMessage)
+
+        let remainingMessage = try await Message.find(messageForUserTwo.requireID(), on: app.db)
+        XCTAssertNotNil(remainingMessage)
+
+        try await manager.deleteMessageIfAuthorized(try messageForUserTwo.requireID(), currentUser: userOne, chat: chat, database: app.db)
+
+        let stillRemaining = try await Message.find(messageForUserTwo.requireID(), on: app.db)
+        XCTAssertNotNil(stillRemaining)
+    }
+}


### PR DESCRIPTION
## Summary
- delete only the authenticated participant's pending messages during chat sync instead of clearing entire conversations
- handle MessageRecievedConfirmation frames on the server and queue/send delivery confirmations from the client
- cover the fixes with server regression tests for GET /chats and websocket acknowledgement handling

## Testing
- `swift test` *(fails: dependency fetch blocked by network proxy 403 responses)*

------
https://chatgpt.com/codex/tasks/task_e_68f48f1ce4e4832194fbb0caaf152604