### PR TITLE
Respect invitation role when joining chats

### DIFF
--- a/AffirmateServer/Docs/ParticipantRoleBackfill.md
+++ b/AffirmateServer/Docs/ParticipantRoleBackfill.md
@@ -1,0 +1,42 @@
+# Participant Role Backfill Plan
+
+## Audit
+
+1. **Identify affected chats**  
+   Run a SQL query (or Fluent script) to list chat IDs where more than one participant currently has the `admin` role:
+   ```sql
+   SELECT chat_id, COUNT(*) AS admin_count
+   FROM participant
+   WHERE role = 'admin'
+   GROUP BY chat_id
+   HAVING COUNT(*) > 1;
+   ```
+   This isolates the chats likely impacted by the historical bug that promoted every invitee to admin.
+
+2. **Spot-check participants**  
+   For each flagged chat, fetch the participant list ordered by `id`. The earliest participant (lowest `id`) should correspond to the chat creator that was seeded as admin at chat creation. Capture the remaining participant `id`s—these are candidates for demotion back to `participant`.
+
+3. **Validate with application logs (optional)**  
+   If available, cross-reference server logs or analytics to ensure no legitimate secondary admins were intentionally granted elevated privileges outside the normal invitation flow.
+
+## Backfill / Migration Strategy
+
+1. **Create a one-time migration**  
+   Write a migration that iterates over each chat. For every chat, keep the participant with the lowest `id` (assumed chat creator) as `admin` and set all other participants to the `participant` role. Using the `id` surrogate key is reliable because the bug only affected invitees created after the chat owner.
+
+2. **Run in a transaction**  
+   Perform updates inside a transaction per chat (or per batch) to guarantee atomicity. In Fluent this can be done with `database.transaction { db in ... }`.
+
+3. **Log adjustments**  
+   Persist a record (e.g., in a maintenance log table or structured logs) with the chat ID and affected participant IDs so the support team can audit after deployment.
+
+4. **Post-migration verification**  
+   Re-run the audit query to confirm every chat now has exactly one admin. Also perform a targeted UI test (or manual check) to ensure demoted participants retain expected capabilities.
+
+5. **Communicate to stakeholders**  
+   Notify support and impacted teams that participant privileges were corrected. Provide guidance in case any user reports missing admin capabilities they previously relied on.
+
+## Preventing Regression
+
+* Keep the new server test (`ChatRouteCollectionTests.test_joinChatUsesInvitationRole`) in CI so any regression re-promoting participants to admin is caught immediately.
+* Consider adding an additional authorization rule in the client/server flows that restricts admin-only actions to participants explicitly flagged as admins in the database.

--- a/AffirmateServer/Sources/AffirmateServer/Routes/ChatRouteCollection.swift
+++ b/AffirmateServer/Sources/AffirmateServer/Routes/ChatRouteCollection.swift
@@ -34,7 +34,7 @@ struct ChatRouteCollection: RouteCollection {
                 )
                 try await newPublicKey.save(on: database)
                 let newParticipant = Participant(
-                    role: .admin,
+                    role: invitation.role,
                     user: try currentUser.requireID(),
                     chat: try newChat.requireID(),
                     publicKey: try newPublicKey.requireID()
@@ -106,7 +106,7 @@ struct ChatRouteCollection: RouteCollection {
                 )
                 try await newPublicKey.save(on: database)
                 let newParticipant = Participant(
-                    role: .admin,
+                    role: invitation.role,
                     user: try currentUser.requireID(),
                     chat: chatId,
                     publicKey: try newPublicKey.requireID()

--- a/AffirmateServer/Sources/AffirmateServer/Routes/ChatRouteCollection.swift
+++ b/AffirmateServer/Sources/AffirmateServer/Routes/ChatRouteCollection.swift
@@ -34,7 +34,7 @@ struct ChatRouteCollection: RouteCollection {
                 )
                 try await newPublicKey.save(on: database)
                 let newParticipant = Participant(
-                    role: invitation.role,
+                    role: .admin,
                     user: try currentUser.requireID(),
                     chat: try newChat.requireID(),
                     publicKey: try newPublicKey.requireID()

--- a/AffirmateServer/Tests/AffirmateServerTests/ChatRouteCollectionTests.swift
+++ b/AffirmateServer/Tests/AffirmateServerTests/ChatRouteCollectionTests.swift
@@ -1,0 +1,90 @@
+//
+//  ChatRouteCollectionTests.swift
+//
+
+@testable import AffirmateServer
+import AffirmateShared
+import Vapor
+import XCTVapor
+
+final class ChatRouteCollectionTests: XCTestCase {
+
+    func test_joinChatUsesInvitationRole() async throws {
+        let app = Application(.testing)
+        defer { app.shutdown() }
+        try! app.setUp()
+        defer { app.tearDown() }
+
+        let adminPassword = try Bcrypt.hash("AdminPass123!")
+        let participantPassword = try Bcrypt.hash("ParticipantPass123!")
+
+        let adminUser = User(
+            firstName: "Admin",
+            lastName: "User",
+            username: "admin-user",
+            email: "admin@example.com",
+            passwordHash: adminPassword
+        )
+        try await adminUser.save(on: app.db)
+
+        let participantUser = User(
+            firstName: "Participant",
+            lastName: "User",
+            username: "participant-user",
+            email: "participant@example.com",
+            passwordHash: participantPassword
+        )
+        try await participantUser.save(on: app.db)
+
+        let chat = Chat(id: UUID(), name: "Test Chat", salt: Data("chat-salt".utf8))
+        try await chat.save(on: app.db)
+
+        let adminPublicKey = PublicKey(
+            signingKey: Data("admin-signing".utf8),
+            encryptionKey: Data("admin-encryption".utf8),
+            user: try adminUser.requireID(),
+            chat: try chat.requireID()
+        )
+        try await adminPublicKey.save(on: app.db)
+
+        let adminParticipant = Participant(
+            role: .admin,
+            user: try adminUser.requireID(),
+            chat: try chat.requireID(),
+            publicKey: try adminPublicKey.requireID()
+        )
+        try await adminParticipant.save(on: app.db)
+
+        let invitation = ChatInvitation(
+            role: .participant,
+            user: try participantUser.requireID(),
+            invitedBy: try adminParticipant.requireID(),
+            chat: try chat.requireID()
+        )
+        try await invitation.save(on: app.db)
+
+        let sessionToken = SessionToken(value: "test-session-token", userID: try participantUser.requireID())
+        try await sessionToken.save(on: app.db)
+
+        let joinConfirmation = ChatInvitationJoin(
+            id: try invitation.requireID(),
+            signingKey: Data("participant-signing".utf8),
+            encryptionKey: Data("participant-encryption".utf8)
+        )
+
+        try await app.test(.POST, "/chats/\(try chat.requireID().uuidString)/join/") { request in
+            request.headers.bearerAuthorization = BearerAuthorization(token: sessionToken.value)
+            try request.content.encode(joinConfirmation, using: JSONEncoder())
+        } afterResponse: { response in
+            XCTAssertEqual(response.status, .ok)
+        }
+
+        let persistedParticipant = try await Participant.query(on: app.db)
+            .filter(\.$chat.$id == try chat.requireID())
+            .filter(\.$user.$id == try participantUser.requireID())
+            .first()
+
+        let participant = try XCTUnwrap(persistedParticipant)
+        XCTAssertEqual(participant.role, .participant)
+    }
+}


### PR DESCRIPTION
## Summary
- update the chat join handler to assign the participant role from the invitation
- add coverage that joining with a participant invitation persists the correct role
- document an audit and migration plan to correct historical participant role data

## Testing
- `swift test` *(fails: package dependencies cannot be fetched from GitHub in the sandboxed environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f48f1e16f48321915cebb7627d2add