### PR TITLE
Add expiration enforcement for session tokens

### DIFF
--- a/AffirmateServer/Sources/AffirmateServer/Configure.swift
+++ b/AffirmateServer/Sources/AffirmateServer/Configure.swift
@@ -24,6 +24,7 @@ fileprivate func configureDatabase(for app: Application) {
     app.migrations.add(Participant.Migration())
     app.migrations.add(ChatInvitation.Migration())
     app.migrations.add(SessionToken.Migration())
+    app.migrations.add(SessionToken.ExpiryMigration())
     app.migrations.add(Message.Migration())
 }
 
@@ -99,7 +100,7 @@ public func configure(_ app: Application) throws {
     
     let chatWebSocketManager = ChatWebSocketManager(eventLoop: app.eventLoopGroup.next())
     app
-        .grouped(SessionToken.authenticator(), SessionToken.guardMiddleware())
+        .grouped(SessionToken.authenticator(), SessionToken.expirationMiddleware(), SessionToken.guardMiddleware())
         .webSocket("chats", ":chatId") { request, webSocket async in
             await chatWebSocketManager.connect(request, webSocket)
         }

--- a/AffirmateServer/Sources/AffirmateServer/Models/SessionToken.swift
+++ b/AffirmateServer/Sources/AffirmateServer/Models/SessionToken.swift
@@ -22,6 +22,9 @@ final class SessionToken: Model, Content {
     
     /// The user who owns this session.
     @Parent(key: "user_id") var user: User
+
+    /// The moment when this token expires.
+    @OptionalField(key: "expires_at") var expiresAt: Date?
     
     /// Conform to `Model`.
     init() { }
@@ -31,10 +34,12 @@ final class SessionToken: Model, Content {
     ///   - id: The id for the database.
     ///   - value: The session key data.
     ///   - userID: The user who owns this session.
-    init(id: UUID? = nil, value: String, userID: User.IDValue) {
+    ///   - expiresAt: The timestamp when this session becomes invalid.
+    init(id: UUID? = nil, value: String, userID: User.IDValue, expiresAt: Date? = nil) {
         self.id = id
         self.value = value
         self.$user.id = userID
+        self.expiresAt = expiresAt
     }
     
     /// Handle asyncronous database migration; creating and destroying the `SessionToken` table.
@@ -56,19 +61,68 @@ final class SessionToken: Model, Content {
             try await database.schema(SessionToken.schema).delete()
         }
     }
+
+    /// Adds expiration metadata to existing session tokens.
+    struct ExpiryMigration: AsyncMigration {
+        var name: String { "SessionTokenExpiryMigration" }
+
+        func prepare(on database: Database) async throws {
+            try await database.schema(SessionToken.schema)
+                .field("expires_at", .datetime)
+                .update()
+
+            let expiration = Date().addingTimeInterval(SessionToken.defaultExpirationInterval)
+            try await SessionToken.query(on: database)
+                .set(\.$expiresAt, to: Optional(expiration))
+                .update()
+        }
+
+        func revert(on database: Database) async throws {
+            try await database.schema(SessionToken.schema)
+                .deleteField("expires_at")
+        }
+    }
 }
 
 extension SessionToken: ModelTokenAuthenticatable {
 
     /// Reference the value of the token
     static let valueKey = \SessionToken.$value
-    
+
     /// Reference the user who owns the token
     static let userKey = \SessionToken.$user
 
     /// Assert whether the token is still valid.
     var isValid: Bool {
-        // TODO: Session tokens should expire.
-        true // Does not expire
+        guard let expiresAt else { return false }
+        return expiresAt > Date()
+    }
+
+    /// The default lifetime for newly created session tokens.
+    static let defaultExpirationInterval: TimeInterval = 60 * 60 * 24
+}
+
+extension SessionToken {
+
+    /// Middleware that enforces token expiration and prunes expired tokens.
+    struct ExpirationMiddleware: AsyncMiddleware {
+        func respond(to request: Request, chainingTo next: AsyncResponder) async throws -> Response {
+            guard let token = request.auth.get(SessionToken.self) else {
+                return try await next.respond(to: request)
+            }
+
+            guard token.isValid else {
+                try await token.delete(on: request.db)
+                request.auth.logout(SessionToken.self)
+                throw Abort(.unauthorized)
+            }
+
+            return try await next.respond(to: request)
+        }
+    }
+
+    /// Provide middleware that should run after authentication to validate expiration.
+    static func expirationMiddleware() -> ExpirationMiddleware {
+        ExpirationMiddleware()
     }
 }

--- a/AffirmateServer/Sources/AffirmateServer/Models/User.swift
+++ b/AffirmateServer/Sources/AffirmateServer/Models/User.swift
@@ -74,7 +74,8 @@ final class User: Model, Content {
     func generateToken() throws -> SessionToken {
         try .init(
             value: [UInt8].random(count: 32).base64,
-            userID: self.requireID()
+            userID: self.requireID(),
+            expiresAt: Date().addingTimeInterval(SessionToken.defaultExpirationInterval)
         )
     }
     

--- a/AffirmateServer/Sources/AffirmateServer/Routes/AuthenticationRouteCollection.swift
+++ b/AffirmateServer/Sources/AffirmateServer/Routes/AuthenticationRouteCollection.swift
@@ -62,7 +62,7 @@ struct AuthenticationRouteCollection: RouteCollection {
 //            return .ok
 //        }
         
-        let tokenProtected = auth.grouped(SessionToken.authenticator(), SessionToken.guardMiddleware())
+        let tokenProtected = auth.grouped(SessionToken.authenticator(), SessionToken.expirationMiddleware(), SessionToken.guardMiddleware())
         
         // MARK: - POST: /auth/logout
         tokenProtected.post("logout") { request -> HTTPStatus in

--- a/AffirmateServer/Sources/AffirmateServer/Routes/ChatRouteCollection.swift
+++ b/AffirmateServer/Sources/AffirmateServer/Routes/ChatRouteCollection.swift
@@ -12,7 +12,7 @@ import Vapor
 struct ChatRouteCollection: RouteCollection {
     
     func boot(routes: RoutesBuilder) throws {
-        let tokenProtected = routes.grouped(SessionToken.authenticator(), SessionToken.guardMiddleware()) // Auth and guard with session token
+        let tokenProtected = routes.grouped(SessionToken.authenticator(), SessionToken.expirationMiddleware(), SessionToken.guardMiddleware()) // Auth and guard with session token
         let chats = tokenProtected.grouped("chats")
         
         // MARK: - POST "/chats": Creates a new blank chat, adds the current user as a participant, and invites any other specified users to the chat.

--- a/AffirmateServer/Sources/AffirmateServer/Routes/MeRouteCollection.swift
+++ b/AffirmateServer/Sources/AffirmateServer/Routes/MeRouteCollection.swift
@@ -13,7 +13,7 @@ struct MeRouteCollection: RouteCollection {
     func boot(routes: RoutesBuilder) throws {
         // "/me" requires the request header to contain a bearer token
         let me = routes
-            .grouped(SessionToken.authenticator(), SessionToken.guardMiddleware()) // Auth and guard with session token
+            .grouped(SessionToken.authenticator(), SessionToken.expirationMiddleware(), SessionToken.guardMiddleware()) // Auth and guard with session token
             .grouped("me")
         
         // MARK: - GET: /me

--- a/AffirmateServer/Sources/AffirmateServer/Routes/UserRouteCollection.swift
+++ b/AffirmateServer/Sources/AffirmateServer/Routes/UserRouteCollection.swift
@@ -13,7 +13,7 @@ struct UserRouteCollection: RouteCollection {
     
     func boot(routes: RoutesBuilder) throws {
         
-        let tokenProtected = routes.grouped(SessionToken.authenticator(), SessionToken.guardMiddleware())
+        let tokenProtected = routes.grouped(SessionToken.authenticator(), SessionToken.expirationMiddleware(), SessionToken.guardMiddleware())
         let users = tokenProtected.grouped("users")
         
         users.get("find") { request async throws -> [UserPublic] in

--- a/AffirmateServer/Tests/AffirmateServerTests/AuthenticationRouteCollectionTests.swift
+++ b/AffirmateServer/Tests/AffirmateServerTests/AuthenticationRouteCollectionTests.swift
@@ -42,12 +42,60 @@ final class AuthenticationRouteCollectionTests: XCTestCase {
         let app = Application(.testing)
         defer { app.shutdown() }
         try! app.setUp()
-        
+
         try await app
             .signUp()
             .login()
             .logout()
-        
+
+        app.tearDown()
+    }
+
+    func test_expiredTokenIsRejectedAndPruned() async throws {
+        let app = Application(.testing)
+        defer { app.shutdown() }
+        try! app.setUp()
+
+        try await app
+            .signUp()
+            .login()
+
+        let optionalToken = try await SessionToken.query(on: app.db).with(\.$user).first()
+        let token = try XCTUnwrap(optionalToken)
+        token.expiresAt = Date(timeIntervalSince1970: 0)
+        try await token.save(on: app.db)
+
+        try await app.test(.POST, "/auth/logout/") { request in
+            request.headers.bearerAuthorization = BearerAuthorization(token: token.value)
+        } afterResponse: { response in
+            XCTAssertEqual(response.status, .unauthorized)
+            let tokens = try await SessionToken.query(on: app.db).all()
+            XCTAssertTrue(tokens.isEmpty)
+        }
+
+        app.tearDown()
+    }
+
+    func test_freshTokenAuthenticatesProtectedRoute() async throws {
+        let app = Application(.testing)
+        defer { app.shutdown() }
+        try! app.setUp()
+
+        try await app
+            .signUp()
+            .login()
+
+        let optionalToken = try await SessionToken.query(on: app.db).first()
+        let token = try XCTUnwrap(optionalToken)
+        XCTAssertNotNil(token.expiresAt)
+        XCTAssertTrue(token.isValid)
+
+        try await app.test(.POST, "/auth/logout/") { request in
+            request.headers.bearerAuthorization = BearerAuthorization(token: token.value)
+        } afterResponse: { response in
+            XCTAssertEqual(response.status, .ok)
+        }
+
         app.tearDown()
     }
 }


### PR DESCRIPTION
## Summary
- add expiration metadata for session tokens with a follow-up migration and middleware enforcement
- ensure token generation stores an expiry timestamp and expired tokens are pruned during authentication while backfilling existing records during the migration
- expand authentication tests to cover expired-token rejection and valid-token access

## Testing
- `swift test` *(fails: unable to fetch package dependencies due to 403 CONNECT tunnel errors)*

------
https://chatgpt.com/codex/tasks/task_e_68f48f20c3cc83218ca97b0af2b49de6