### PR TITLE
Remove disableAutomaticPackageResolution flag from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           xcodebuild -resolvePackageDependencies \
             -project Affirmate.xcodeproj \
             -scheme "${{ matrix.scheme }}" \
-            -clonedSourcePackagesDirPath "$RUNNER_TEMP/SourcePackages"
+            -onlyUsePackageVersionsFromResolvedFile
 
       - name: Build and test
         run: |
@@ -50,8 +50,8 @@ jobs:
             -project Affirmate.xcodeproj \
             -scheme "${{ matrix.scheme }}" \
             -destination "${{ matrix.destination }}" \
-            -clonedSourcePackagesDirPath "$RUNNER_TEMP/SourcePackages" \
-            -skipPackagePluginValidation
+            -skipPackagePluginValidation \
+            -disableAutomaticPackageResolution
 
   server:
     name: Server tests (${{ matrix.os }})
@@ -127,7 +127,7 @@ jobs:
           xcodebuild -resolvePackageDependencies \
             -project Affirmate.xcodeproj \
             -scheme Affirmate \
-            -clonedSourcePackagesDirPath "$RUNNER_TEMP/SourcePackages"
+            -onlyUsePackageVersionsFromResolvedFile
 
       - name: Run integration tests
         env:
@@ -138,8 +138,8 @@ jobs:
             -project Affirmate.xcodeproj \
             -scheme Affirmate \
             -destination 'platform=macOS' \
-            -clonedSourcePackagesDirPath "$RUNNER_TEMP/SourcePackages" \
-            -skipPackagePluginValidation
+            -skipPackagePluginValidation \
+            -disableAutomaticPackageResolution
 
       - name: Shutdown server
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,20 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-26]
+    services:
+      postgres:
+        image: ${{ matrix.os == 'ubuntu-latest' && 'postgres:16' || '' }}
+        env:
+          POSTGRES_USER: vapor_username
+          POSTGRES_PASSWORD: vapor_password
+          POSTGRES_DB: vapor_database
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -67,11 +81,38 @@ jobs:
       - name: Set up Swift
         uses: swift-actions/setup-swift@v2
         with:
-          swift-version: '5.10'
+          swift-version: '6.2'
+
+      - name: Install and start PostgreSQL (macOS)
+        if: matrix.os == 'macos-26'
+        run: |
+          brew install postgresql@16
+          POSTGRES_PREFIX="$(brew --prefix postgresql@16)"
+          PGDATA="$POSTGRES_PREFIX/var/postgresql@16"
+          mkdir -p "$PGDATA"
+          "$POSTGRES_PREFIX/bin/initdb" -U runner "$PGDATA"
+          "$POSTGRES_PREFIX/bin/pg_ctl" -D "$PGDATA" -o "-c listen_addresses=localhost" -l "$PGDATA/server.log" start
+          "$POSTGRES_PREFIX/bin/createuser" --superuser vapor_username || true
+          "$POSTGRES_PREFIX/bin/createdb" -O vapor_username vapor_database || true
+          "$POSTGRES_PREFIX/bin/psql" -v ON_ERROR_STOP=1 -d postgres -c "ALTER USER vapor_username WITH PASSWORD 'vapor_password';"
 
       - name: Run server tests
         working-directory: AffirmateServer
+        env:
+          DATABASE_HOST: localhost
+          DATABASE_USERNAME: vapor_username
+          DATABASE_PASSWORD: vapor_password
+          DATABASE_NAME: vapor_database
         run: swift test
+
+      - name: Stop PostgreSQL (macOS)
+        if: always() && matrix.os == 'macos-26'
+        run: |
+          POSTGRES_PREFIX="$(brew --prefix postgresql@16)"
+          PGDATA="$POSTGRES_PREFIX/var/postgresql@16"
+          if [ -f "$PGDATA/postmaster.pid" ]; then
+            "$POSTGRES_PREFIX/bin/pg_ctl" -D "$PGDATA" stop
+          fi
 
   integration:
     name: Integration tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Set up Swift
         uses: swift-actions/setup-swift@v2
         with:
-          swift-version: '6.2'
+          swift-version: '5.10'
 
       - name: Run server tests
         working-directory: AffirmateServer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,16 +53,12 @@ jobs:
             -skipPackagePluginValidation \
             -disableAutomaticPackageResolution
 
-  server:
-    name: Server tests (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-26]
+  server-ubuntu:
+    name: Server tests (ubuntu-latest)
+    runs-on: ubuntu-latest
     services:
       postgres:
-        image: ${{ matrix.os == 'ubuntu-latest' && 'postgres:16' || '' }}
+        image: postgres:16
         env:
           POSTGRES_USER: vapor_username
           POSTGRES_PASSWORD: vapor_password
@@ -83,8 +79,28 @@ jobs:
         with:
           swift-version: '6.2'
 
-      - name: Install and start PostgreSQL (macOS)
-        if: matrix.os == 'macos-26'
+      - name: Run server tests
+        working-directory: AffirmateServer
+        env:
+          DATABASE_HOST: localhost
+          DATABASE_USERNAME: vapor_username
+          DATABASE_PASSWORD: vapor_password
+          DATABASE_NAME: vapor_database
+        run: swift test
+
+  server-macos:
+    name: Server tests (macos-26)
+    runs-on: macos-26
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Swift
+        uses: swift-actions/setup-swift@v2
+        with:
+          swift-version: '6.2'
+
+      - name: Install and start PostgreSQL
         run: |
           brew install postgresql@16
           POSTGRES_PREFIX="$(brew --prefix postgresql@16)"
@@ -105,8 +121,8 @@ jobs:
           DATABASE_NAME: vapor_database
         run: swift test
 
-      - name: Stop PostgreSQL (macOS)
-        if: always() && matrix.os == 'macos-26'
+      - name: Stop PostgreSQL
+        if: always()
         run: |
           POSTGRES_PREFIX="$(brew --prefix postgresql@16)"
           PGDATA="$POSTGRES_PREFIX/var/postgresql@16"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,7 @@ jobs:
             -project Affirmate.xcodeproj \
             -scheme "${{ matrix.scheme }}" \
             -destination "${{ matrix.destination }}" \
-            -skipPackagePluginValidation \
-            -disableAutomaticPackageResolution
+            -skipPackagePluginValidation
 
   server:
     name: Server tests (${{ matrix.os }})
@@ -124,8 +123,7 @@ jobs:
             -project Affirmate.xcodeproj \
             -scheme Affirmate \
             -destination 'platform=macOS' \
-            -skipPackagePluginValidation \
-            -disableAutomaticPackageResolution
+            -skipPackagePluginValidation
 
       - name: Shutdown server
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,13 @@ jobs:
       - name: Select Xcode
         run: sudo xcode-select -s /Applications/Xcode_26.app
 
+      - name: Resolve package dependencies
+        run: |
+          xcodebuild -resolvePackageDependencies \
+            -project Affirmate.xcodeproj \
+            -scheme "${{ matrix.scheme }}" \
+            -clonedSourcePackagesDirPath "$RUNNER_TEMP/SourcePackages"
+
       - name: Build and test
         run: |
           set -o pipefail
@@ -43,6 +50,7 @@ jobs:
             -project Affirmate.xcodeproj \
             -scheme "${{ matrix.scheme }}" \
             -destination "${{ matrix.destination }}" \
+            -clonedSourcePackagesDirPath "$RUNNER_TEMP/SourcePackages" \
             -skipPackagePluginValidation
 
   server:
@@ -114,6 +122,13 @@ jobs:
           echo $! > "$RUNNER_TEMP/affirmate-server.pid"
           sleep 15
 
+      - name: Resolve package dependencies
+        run: |
+          xcodebuild -resolvePackageDependencies \
+            -project Affirmate.xcodeproj \
+            -scheme Affirmate \
+            -clonedSourcePackagesDirPath "$RUNNER_TEMP/SourcePackages"
+
       - name: Run integration tests
         env:
           AFFIRMATE_INTEGRATION_TESTS: '1'
@@ -123,6 +138,7 @@ jobs:
             -project Affirmate.xcodeproj \
             -scheme Affirmate \
             -destination 'platform=macOS' \
+            -clonedSourcePackagesDirPath "$RUNNER_TEMP/SourcePackages" \
             -skipPackagePluginValidation
 
       - name: Shutdown server


### PR DESCRIPTION
This flag was preventing Xcode from resolving packages automatically,
which caused the build to fail with "Missing package product 'CodeScanner'"
when there was any stale package resolution state.